### PR TITLE
Use matrix to define the jobs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   build_job:
     strategy:
+      fail-fast: false
+      max-parallel: 4
       matrix:
         ros_distro: [humble, rolling]
     name: build_${{ matrix.ros_distro }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,24 +6,19 @@ on:
     - cron: '17 1 * * *'
 
 jobs:
-  build_humble:
+  build_job:
+    strategy:
+      matrix:
+        ros_distro: [humble, rolling]
+    name: build_${{ matrix.ros_distro }}
     runs-on: ubuntu-22.04
+    env:
+      repos_branch: ${{ matrix.ros_distro == 'rolling' && 'main' || matrix.ros_distro }}
     steps:
       - uses: jspricke/ros-deb-builder-action@main
         with:
           DEB_DISTRO: jammy
-          ROS_DISTRO: humble
-          REPOS_FILE: https://raw.githubusercontent.com/ros-planning/moveit2_tutorials/humble/moveit2_tutorials.repos
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SQUASH_HISTORY: true
-
-  build_rolling:
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: jspricke/ros-deb-builder-action@main
-        with:
-          DEB_DISTRO: jammy
-          ROS_DISTRO: rolling
-          REPOS_FILE: https://raw.githubusercontent.com/ros-planning/moveit2_tutorials/main/moveit2_tutorials.repos
+          ROS_DISTRO: ${{ matrix.ros_distro }}
+          REPOS_FILE: https://raw.githubusercontent.com/ros-planning/moveit2_tutorials/${{ env.repos_branch }}/moveit2_tutorials.repos
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SQUASH_HISTORY: true


### PR DESCRIPTION
First of all, thank you so much for the work sharing the jspricke/ros-deb-builder-action action! I'm pretty sure it's going to be really useful for many of us.

I guess this repo is just an example of how to use the action but I thought it could be good to use a matrix strategy for defining the jobs. That way we avoid some code/yaml duplication and make it somehow easier to extend.

What do you think?

Best.
